### PR TITLE
Fix Netlify configuration error by removing duplicate sections. The `…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,6 @@
   NODE_VERSION = "18"
   FIREBASE_PROJECT_ID = "morgensterhospital-1088c"
 
-[build.environment]
-  NODE_VERSION = "18"
-  FIREBASE_PROJECT_ID = "morgensterhospital-1088c"
-
 [[redirects]]
   from = "/*"
   to = "/index.html"
@@ -20,10 +16,6 @@
   to = "/.netlify/functions/:splat"
   status = 200
 
-[[redirects]]
-  from = "/.netlify/functions/*"
-  to = "/.netlify/functions/:splat"
-  status = 200
 [[headers]]
   for = "/assets/*"
   [headers.values]
@@ -36,9 +28,6 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Methods = "GET, POST, PUT, DELETE, OPTIONS"
-    Access-Control-Allow-Headers = "Content-Type, Authorization"
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Methods = "GET, POST, PUT, DELETE, OPTIONS"
     Access-Control-Allow-Headers = "Content-Type, Authorization"


### PR DESCRIPTION
…netlify.toml` file had duplicate `[build.environment]` and `[[redirects]]` sections, which caused a parsing error during Netlify deployments. This change removes the duplicate sections, resolving the build failure.