### PR TITLE
feat: Redesign AccountAssistantDashboard to use dark theme

### DIFF
--- a/src/components/common/M3Button.vue
+++ b/src/components/common/M3Button.vue
@@ -143,62 +143,62 @@ const handleClick = (event) => {
 
 /* Variants */
 .m3-button--filled {
-  background-color: #0066B2;
-  color: white;
+  background-color: var(--primary-color, #0066B2);
+  color: var(--on-primary-color, white);
 }
 
 .m3-button--outlined {
   background-color: transparent;
-  color: #0066B2;
-  border: 1px solid #0066B2;
+  color: var(--primary-color, #0066B2);
+  border: 1px solid var(--primary-color, #0066B2);
 }
 
 .m3-button--text {
   background-color: transparent;
-  color: #0066B2;
+  color: var(--primary-color, #0066B2);
 }
 
 /* Color variations */
 .m3-button--secondary.m3-button--filled {
-  background-color: #14B8A6;
-  color: white;
+  background-color: var(--secondary-color, #14B8A6);
+  color: var(--on-secondary-color, white);
 }
 
 .m3-button--secondary.m3-button--outlined {
-  border-color: #14B8A6;
-  color: #14B8A6;
+  border-color: var(--secondary-color, #14B8A6);
+  color: var(--secondary-color, #14B8A6);
 }
 
 .m3-button--secondary.m3-button--text {
-  color: #14B8A6;
+  color: var(--secondary-color, #14B8A6);
 }
 
 .m3-button--error.m3-button--filled {
-  background-color: #DC2626;
-  color: white;
+  background-color: var(--error-color, #DC2626);
+  color: var(--on-error-color, white);
 }
 
 .m3-button--error.m3-button--outlined {
-  border-color: #DC2626;
-  color: #DC2626;
+  border-color: var(--error-color, #DC2626);
+  color: var(--error-color, #DC2626);
 }
 
 .m3-button--error.m3-button--text {
-  color: #DC2626;
+  color: var(--error-color, #DC2626);
 }
 
 .m3-button--success.m3-button--filled {
-  background-color: #16A34A;
-  color: white;
+  background-color: var(--success-color, #16A34A);
+  color: var(--on-success-color, white);
 }
 
 .m3-button--success.m3-button--outlined {
-  border-color: #16A34A;
-  color: #16A34A;
+  border-color: var(--success-color, #16A34A);
+  color: var(--success-color, #16A34A);
 }
 
 .m3-button--success.m3-button--text {
-  color: #16A34A;
+  color: var(--success-color, #16A34A);
 }
 
 /* Full width */

--- a/src/components/common/M3TextField.vue
+++ b/src/components/common/M3TextField.vue
@@ -167,7 +167,7 @@ const handleBlur = (event) => {
   outline: none;
   background: transparent;
   font-size: 16px;
-  color: #1F2937;
+  color: var(--text-light, #1F2937);
   z-index: 1;
 }
 
@@ -179,24 +179,24 @@ const handleBlur = (event) => {
 .m3-text-field__label {
   position: absolute;
   left: 16px;
-  color: #6B7280;
+  color: var(--text-muted, #6B7280);
   font-size: 16px;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   pointer-events: none;
   z-index: 2;
-  background: white;
+  background: var(--background-dark, white);
   padding: 0 4px;
 }
 
 .m3-text-field__required {
-  color: #DC2626;
+  color: var(--error-color, #DC2626);
 }
 
 /* Outlined variant */
 .m3-text-field--outlined .m3-text-field__input {
   padding: 16px;
   border-radius: 4px;
-  border: 1px solid #D1D5DB;
+  border: 1px solid var(--text-muted, #D1D5DB);
   transition: border-color 0.2s ease;
 }
 
@@ -217,8 +217,8 @@ const handleBlur = (event) => {
 .m3-text-field--filled .m3-text-field__input {
   padding: 20px 16px 8px;
   border-radius: 4px 4px 0 0;
-  background: #F3F4F6;
-  border-bottom: 2px solid #D1D5DB;
+  background: var(--surface-dark, #F3F4F6);
+  border-bottom: 2px solid var(--text-muted, #D1D5DB);
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
@@ -261,30 +261,30 @@ const handleBlur = (event) => {
 
 /* Focus states */
 .m3-text-field--focused .m3-text-field__input {
-  border-color: #0066B2;
+  border-color: var(--primary-color, #0066B2);
 }
 
 .m3-text-field--focused .m3-text-field__label {
-  color: #0066B2;
+  color: var(--primary-color, #0066B2);
 }
 
 .m3-text-field--filled.m3-text-field--focused .m3-text-field__input {
-  background: #EBF8FF;
-  border-bottom-color: #0066B2;
+  background: var(--primary-hover, #EBF8FF);
+  border-bottom-color: var(--primary-color, #0066B2);
 }
 
 /* Error states */
 .m3-text-field--error .m3-text-field__input {
-  border-color: #DC2626;
+  border-color: var(--error-color, #DC2626);
 }
 
 .m3-text-field--error .m3-text-field__label {
-  color: #DC2626;
+  color: var(--error-color, #DC2626);
 }
 
 .m3-text-field--filled.m3-text-field--error .m3-text-field__input {
-  background: #FEF2F2;
-  border-bottom-color: #DC2626;
+  background: var(--error-container, #FEF2F2);
+  border-bottom-color: var(--error-color, #DC2626);
 }
 
 /* Disabled state */
@@ -294,8 +294,8 @@ const handleBlur = (event) => {
 }
 
 .m3-text-field--disabled .m3-text-field__input {
-  background: #F9FAFB;
-  color: #9CA3AF;
+  background: var(--surface-dark, #F9FAFB);
+  color: var(--text-muted, #9CA3AF);
 }
 
 /* Supporting text */
@@ -307,10 +307,10 @@ const handleBlur = (event) => {
 }
 
 .m3-text-field__error {
-  color: #DC2626;
+  color: var(--error-color, #DC2626);
 }
 
 .m3-text-field__helper {
-  color: #6B7280;
+  color: var(--text-muted, #6B7280);
 }
 </style>

--- a/src/views/dashboards/AccountAssistantDashboard.vue
+++ b/src/views/dashboards/AccountAssistantDashboard.vue
@@ -1,159 +1,108 @@
 <template>
-  <div class="dashboard">
-    <!-- Page Header -->
-    <div class="dashboard-header">
-      <div class="header-info">
-        <h1 class="page-title">MORGENSTER HOSPITAL MANAGEMENT SYSTEM</h1>
-        <div class="user-info">
-          LOGGED IN AS: {{ authStore.user?.displayName || 'USER' }}: ACCOUNT ASSISTANT
-        </div>
+  <div class="space-y-6">
+    <!-- Welcome Header -->
+    <div class="flex justify-between items-center">
+      <div>
+        <h1 class="text-2xl font-bold text-text-light">
+          Welcome, {{ authStore.user?.displayName || 'Account Assistant' }}!
+        </h1>
+        <p class="text-text-muted">Here is your financial overview.</p>
       </div>
-
-      <div class="header-actions">
-        <m3-button variant="outlined" @click="navigateTo('/stationery')">
-          STATIONERY
-        </m3-button>
+      <div class="flex items-center space-x-4">
+        <div class="p-4 bg-surface-dark rounded-lg text-center">
+          <p class="text-sm text-text-muted">Date</p>
+          <p class="text-lg font-semibold text-text-light">{{ currentDate }}</p>
+        </div>
+        <div class="p-4 bg-surface-dark rounded-lg text-center">
+          <p class="text-sm text-text-muted">Time</p>
+          <p class="text-lg font-semibold text-text-light">{{ currentTime }}</p>
+        </div>
       </div>
     </div>
 
-    <!-- Main Dashboard Content -->
-    <div class="dashboard-content">
-      <!-- Left Section - Navigation & Actions -->
-      <div class="left-section">
-        <div class="main-actions">
-          <!-- Patient Search -->
-          <div class="search-section">
-            <m3-text-field
-              v-model="searchQuery"
-              placeholder="SEARCH PATIENT NAME AND SURNAME"
-              :icon-leading="mdiMagnify"
-              variant="outlined"
-              @input="handleSearch"
-            />
-
-            <div v-if="searchResults.length > 0" class="search-results">
-              <div
+    <!-- Patient Search -->
+    <div class="p-6 bg-surface-dark rounded-lg mt-6">
+        <h2 class="text-lg font-semibold mb-4">Find a Patient's Financial Record</h2>
+        <div class="relative">
+          <MdiIcon :path="mdiMagnify" size="20" class="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="Search by name or hospital number..."
+            class="w-full pl-10 pr-4 py-2 bg-background-dark border border-gray-600 rounded-lg focus:ring-primary focus:border-primary"
+            @input="handleSearch"
+          />
+          <div
+            v-if="searchResults.length > 0"
+            class="absolute top-full mt-2 w-full bg-background-dark border border-gray-600 rounded-lg shadow-lg z-10 max-h-60 overflow-y-auto"
+          >
+            <ul>
+              <li
                 v-for="patient in searchResults"
                 :key="patient.id"
-                class="search-result-item"
+                class="px-4 py-3 hover:bg-primary/10 cursor-pointer"
                 @click="selectPatient(patient)"
               >
-                <div class="patient-name">
-                  {{ patient.name }} {{ patient.surname }}
-                </div>
-                <div class="patient-details">
-                  {{ patient.hospitalNumber }} • {{ patient.age }} years
-                </div>
-              </div>
-            </div>
+                <p class="font-semibold">{{ patient.name }} {{ patient.surname }}</p>
+                <p class="text-sm text-text-muted">
+                  ID: {{ patient.hospitalNumber }} &bull; Age: {{ patient.age }}
+                </p>
+              </li>
+            </ul>
           </div>
-
-          <m3-button
-            variant="filled"
-            size="large"
-            full-width
-            :icon="mdiChartLine"
-            @click="navigateTo('/reports')"
-            class="main-action-btn"
-          >
-            REPORTS & ANALYTICS
-          </m3-button>
-
-          <m3-button
-            variant="filled"
-            size="large"
-            full-width
-            :icon="mdiPrinter"
-            @click="printCashSales"
-            class="main-action-btn"
-          >
-            PRINT CASH SALES
-          </m3-button>
-
-          <m3-button
-            variant="filled"
-            size="large"
-            full-width
-            :icon="mdiCheckDecagram"
-            @click="navigateTo('/approvals')"
-            class="main-action-btn"
-          >
-            APPROVE BALANCES
-          </m3-button>
         </div>
       </div>
 
-      <!-- Right Section - Stats & DateTime -->
-      <div class="right-section">
-        <!-- Date and Time -->
-        <div class="datetime-section">
-          <div class="datetime-card">
-            <div class="datetime-label">DATE</div>
-            <div class="datetime-value">{{ currentDate }}</div>
-          </div>
-          <div class="datetime-card">
-            <div class="datetime-label">TIME</div>
-            <div class="datetime-value">{{ currentTime }}</div>
-          </div>
+    <!-- Financial Stats Grid -->
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div class="p-6 bg-surface-dark rounded-lg">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-text-muted">Clerks Supervised</p>
+          <MdiIcon :path="mdiAccountSupervisor" size="24" class="text-primary" />
         </div>
-
-        <!-- Supervisory Stats -->
-        <div class="stats-section">
-          <div class="stats-grid">
-            <div class="stat-card primary">
-              <div class="stat-icon">
-                <mdi-icon :path="mdiAccountSupervisor" size="32" />
-              </div>
-              <div class="stat-content">
-                <div class="stat-label">CLERKS SUPERVISED</div>
-                <div class="stat-value">{{ supervisoryStats.clerksSupervised }}</div>
-              </div>
-            </div>
-
-            <div class="stat-card warning">
-              <div class="stat-icon">
-                <mdi-icon :path="mdiClockAlert" size="32" />
-              </div>
-              <div class="stat-content">
-                <div class="stat-label">PENDING APPROVALS</div>
-                <div class="stat-value">{{ supervisoryStats.pendingApprovals }}</div>
-              </div>
-            </div>
-
-            <div class="stat-card success">
-              <div class="stat-icon">
-                <mdi-icon :path="mdiCashMultiple" size="32" />
-              </div>
-              <div class="stat-content">
-                <div class="stat-label">TODAY'S CASH SALES</div>
-                <div class="stat-value">M{{ formatCurrency(supervisoryStats.todayCashSales) }}</div>
-              </div>
-            </div>
-
-            <div class="stat-card info">
-              <div class="stat-icon">
-                <mdi-icon :path="mdiFileDocument" size="32" />
-              </div>
-              <div class="stat-content">
-                <div class="stat-label">REPORTS GENERATED</div>
-                <div class="stat-value">{{ supervisoryStats.reportsGenerated }}</div>
-              </div>
-            </div>
-          </div>
+        <p class="text-3xl font-bold mt-2">{{ supervisoryStats.clerksSupervised }}</p>
+      </div>
+      <div class="p-6 bg-surface-dark rounded-lg">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-text-muted">Pending Approvals</p>
+          <MdiIcon :path="mdiClockAlert" size="24" class="text-yellow-400" />
         </div>
+        <p class="text-3xl font-bold mt-2">{{ supervisoryStats.pendingApprovals }}</p>
+      </div>
+      <div class="p-6 bg-surface-dark rounded-lg">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-text-muted">Today's Cash Sales</p>
+          <MdiIcon :path="mdiCashMultiple" size="24" class="text-green-400" />
+        </div>
+        <p class="text-3xl font-bold mt-2">M{{ formatCurrency(supervisoryStats.todayCashSales) }}</p>
+      </div>
+      <div class="p-6 bg-surface-dark rounded-lg">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-text-muted">Reports Generated</p>
+          <MdiIcon :path="mdiFileDocument" size="24" class="text-indigo-400" />
+        </div>
+        <p class="text-3xl font-bold mt-2">{{ supervisoryStats.reportsGenerated }}</p>
+      </div>
+    </div>
 
-        <!-- Welcome Message -->
-        <div class="welcome-section">
-          <div class="welcome-card">
-            <div class="client-logo">
-              <mdi-icon :path="mdiAccountTie" size="64" color="#0066B2" />
-            </div>
-            <h3>CLIENT NAME AND LOGO</h3>
-            <p>WELCOME MESSAGE</p>
-            <div class="supervisor-note">
-              <p><strong>Supervisory Role:</strong> Monitor accounts clerk activities, approve transactions, and generate supervisory reports.</p>
-            </div>
-          </div>
+    <!-- Actions -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Quick Actions -->
+      <div class="p-6 bg-surface-dark rounded-lg">
+        <h2 class="text-lg font-semibold mb-4">Core Functions</h2>
+        <div class="space-y-4">
+          <button @click="navigateTo('/reports')" class="w-full flex items-center p-4 bg-primary/10 hover:bg-primary/20 rounded-lg transition-colors">
+            <MdiIcon :path="mdiChartLine" size="24" class="mr-3 text-primary" />
+            <span class="font-medium">Reports & Analytics</span>
+          </button>
+          <button @click="printCashSales" class="w-full flex items-center p-4 bg-primary/10 hover:bg-primary/20 rounded-lg transition-colors">
+            <MdiIcon :path="mdiPrinter" size="24" class="mr-3 text-primary" />
+            <span class="font-medium">Print Cash Sales</span>
+          </button>
+          <button @click="navigateTo('/approvals')" class="w-full flex items-center p-4 bg-primary/10 hover:bg-primary/20 rounded-lg transition-colors">
+            <MdiIcon :path="mdiCheckDecagram" size="24" class="mr-3 text-primary" />
+            <span class="font-medium">Approve Balances</span>
+          </button>
         </div>
       </div>
     </div>
@@ -166,8 +115,6 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 import { usePatientStore } from '@/stores/patientStore'
 import MdiIcon from '@/components/common/MdiIcon.vue'
-import M3Button from '@/components/common/M3Button.vue'
-import M3TextField from '@/components/common/M3TextField.vue'
 import {
   mdiChartLine,
   mdiMagnify,
@@ -177,7 +124,6 @@ import {
   mdiClockAlert,
   mdiCashMultiple,
   mdiFileDocument,
-  mdiAccountTie
 } from '@mdi/js'
 
 const router = useRouter()
@@ -265,308 +211,3 @@ onUnmounted(() => {
   }
 })
 </script>
-
-<style scoped>
-.dashboard {
-  min-height: 100vh;
-  background: #F7F9FC;
-  font-family: 'Roboto', sans-serif;
-}
-
-.dashboard-header {
-  background: white;
-  padding: 24px 32px;
-  border-bottom: 1px solid #E5E7EB;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.header-info {
-  flex: 1;
-}
-
-.page-title {
-  font-size: 24px;
-  font-weight: 700;
-  color: #0066B2;
-  margin: 0 0 8px 0;
-}
-
-.user-info {
-  font-size: 14px;
-  color: #6B7280;
-  font-weight: 500;
-}
-
-.header-actions {
-  display: flex;
-  gap: 12px;
-}
-
-.dashboard-content {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  padding: 32px;
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-.left-section,
-.right-section {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-}
-
-/* Main Actions */
-.main-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.main-action-btn {
-  height: 64px;
-  font-size: 16px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-}
-
-/* Search Section */
-.search-section {
-  position: relative;
-}
-
-.search-results {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  background: white;
-  border: 1px solid #E5E7EB;
-  border-radius: 8px;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-  max-height: 300px;
-  overflow-y: auto;
-  z-index: 10;
-}
-
-.search-result-item {
-  padding: 16px;
-  border-bottom: 1px solid #F3F4F6;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.search-result-item:hover {
-  background: #F9FAFB;
-}
-
-.search-result-item:last-child {
-  border-bottom: none;
-}
-
-.patient-name {
-  font-weight: 600;
-  color: #1F2937;
-  margin-bottom: 4px;
-}
-
-.patient-details {
-  font-size: 14px;
-  color: #6B7280;
-}
-
-/* DateTime Section */
-.datetime-section {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.datetime-card {
-  background: white;
-  padding: 24px;
-  border-radius: 12px;
-  text-align: center;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-}
-
-.datetime-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: #6B7280;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  margin-bottom: 8px;
-}
-
-.datetime-value {
-  font-size: 18px;
-  font-weight: 700;
-  color: #0066B2;
-}
-
-/* Stats Section */
-.stats-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.stat-card {
-  background: white;
-  padding: 20px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.stat-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-}
-
-.stat-icon {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.stat-card.primary .stat-icon {
-  background: linear-gradient(135deg, #0066B2 0%, #0052A3 100%);
-  color: white;
-}
-
-.stat-card.success .stat-icon {
-  background: linear-gradient(135deg, #16A34A 0%, #15803D 100%);
-  color: white;
-}
-
-.stat-card.warning .stat-icon {
-  background: linear-gradient(135deg, #F59E0B 0%, #D97706 100%);
-  color: white;
-}
-
-.stat-card.info .stat-icon {
-  background: linear-gradient(135deg, #3B82F6 0%, #2563EB 100%);
-  color: white;
-}
-
-.stat-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.stat-label {
-  font-size: 10px;
-  font-weight: 600;
-  color: #6B7280;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 4px;
-}
-
-.stat-value {
-  font-size: 20px;
-  font-weight: 800;
-  color: #1F2937;
-  line-height: 1;
-}
-
-/* Welcome Section */
-.welcome-section {
-  flex: 1;
-}
-
-.welcome-card {
-  background: white;
-  padding: 32px;
-  border-radius: 12px;
-  text-align: center;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.client-logo {
-  margin-bottom: 24px;
-}
-
-.welcome-card h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #0066B2;
-  margin: 0 0 12px 0;
-}
-
-.welcome-card p {
-  font-size: 14px;
-  color: #6B7280;
-  margin: 0 0 24px 0;
-}
-
-.supervisor-note {
-  background: #F0F9FF;
-  padding: 16px;
-  border-radius: 8px;
-  border-left: 4px solid #0066B2;
-}
-
-.supervisor-note p {
-  font-size: 12px;
-  color: #1F2937;
-  margin: 0;
-  text-align: left;
-}
-
-/* Responsive Design */
-@media (max-width: 1024px) {
-  .dashboard-content {
-    grid-template-columns: 1fr;
-    gap: 24px;
-    padding: 24px 16px;
-  }
-
-  .dashboard-header {
-    padding: 16px 20px;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 16px;
-  }
-
-  .header-actions {
-    width: 100%;
-    justify-content: flex-end;
-  }
-
-  .page-title {
-    font-size: 20px;
-  }
-
-  .datetime-section {
-    grid-template-columns: 1fr;
-  }
-
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .main-action-btn {
-    height: 56px;
-    font-size: 14px;
-  }
-}
-</style>


### PR DESCRIPTION
This commit redesigns the AccountAssistantDashboard to use the dark theme. It removes the old scoped CSS and replaces the template with a new structure that uses the dark theme colors from `tailwind.config.js`.