### PR TITLE
fix(seeding): Correct Firebase Admin initialization for user seeding

### DIFF
--- a/netlify/functions/lib/firebase-admin.js
+++ b/netlify/functions/lib/firebase-admin.js
@@ -19,4 +19,6 @@ if (!admin.apps.length) {
   })
 }
 
-export const db = admin.firestore()
+const db = admin.firestore()
+
+export { admin, db }

--- a/netlify/functions/seed-users.js
+++ b/netlify/functions/seed-users.js
@@ -1,5 +1,4 @@
-import { db } from './lib/firebase-admin.js';
-import admin from 'firebase-admin';
+import { admin, db } from './lib/firebase-admin.js';
 
 const auth = admin.auth();
 


### PR DESCRIPTION
The user seeding script in the Netlify function `netlify/functions/seed-users.js` was failing to create users in Firebase Authentication. This was because it was importing a new, uninitialized `firebase-admin` instance instead of using the shared, initialized instance from `netlify/functions/lib/firebase-admin.js`.

This change modifies `netlify/functions/lib/firebase-admin.js` to export the initialized `admin` object. The `seed-users.js` function is then updated to import this shared `admin` instance, ensuring that `admin.auth()` is called on a correctly configured instance. This allows the user creation process to succeed.